### PR TITLE
Add missing Err reference

### DIFF
--- a/lib/upload-file.js
+++ b/lib/upload-file.js
@@ -1,4 +1,5 @@
 const fetch = require("node-fetch");
+const Err = require("./error.js");
 
 const getFileURL = require("./get-file-url.js");
 


### PR DESCRIPTION
#### Describe the PR

upload-file.js was missing a reference to Err, resulting in an error saying "ReferenceError: Err is not defined" instead of the actual error.

#### Related issues

None.

#### Status

Ready
